### PR TITLE
Update cloudkey.gemspec to pass validation

### DIFF
--- a/cloudkey.gemspec
+++ b/cloudkey.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "cloudkey"
   s.rdoc_options = ["--line-numbers", "--main", "README.md"]
-  s.extra_rdoc_files = ["README.md"]
+  s.extra_rdoc_files = ["Readme.md"]
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
changed README.md to Readme.md to fix validation message (I hope it's as simple as that).

example warning: 
cloudkey at /home/admin/apps/fiverr/shared/bundle/ruby/1.9.1/bundler/gems/cloudkey-72090346dfca did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
 The validation message from Rubygems was:
 ["README.md"] are not files
